### PR TITLE
商品一覧表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'carrierwave'
 gem 'fog-aws'
 gem 'mini_magick'
 
+#テストで導入
+gem 'rails-controller-testing'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -294,6 +298,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.18, < 0.5)
   puma (~> 3.0)
   rails (~> 5.0.1)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   spring

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
-  def index 
+  def index
+    @items = Item.all
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ApplicationRecord
+end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -32,51 +32,16 @@
     %h3.main__items--center-text
       レディース新着アイテム
     .main__items-container.clearfix
+    - @items.each do |item|
       .main__items-box
         .main__items-box--img
-          = image_tag("https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m96316226986_1.jpg?1543710468", class: "box--image")
+          = image_tag("#{item.image}", class: "box--image")
         .main__items-box--text
           %h3.main__items-box--title
-            タイトル
+            = item.name
           .main__items-box--num.clearfix
             .main__items-box--price.l-left
-              ¥8888
-            %p.main__items-box--tax
-              (税込)
-
-      .main__items-box
-        .main__items-box--img
-          = image_tag("https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m96316226986_1.jpg?1543710468", class: "box--image")
-        .main__items-box--text
-          %h3.main__items-box--title
-            タイトル
-          .main__items-box--num.clearfix
-            .main__items-box--price.l-left
-              ¥3500
-            %p.main__items-box--tax
-              (税込)
-
-      .main__items-box
-        .main__items-box--img
-          = image_tag("https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m96316226986_1.jpg?1543710468", class: "box--image")
-        .main__items-box--text
-          %h3.main__items-box--title
-            タイトル
-          .main__items-box--num.clearfix
-            .main__items-box--price.l-left
-              ¥3500
-            %p.main__items-box--tax
-              (税込)
-
-      .main__items-box
-        .main__items-box--img
-          = image_tag("https://static-mercari-jp-imgtr2.akamaized.net/thumb/photos/m96316226986_1.jpg?1543710468", class: "box--image")
-        .main__items-box--text
-          %h3.main__items-box--title
-            タイトル
-          .main__items-box--num.clearfix
-            .main__items-box--price.l-left
-              ¥3500
+              = item.price
             %p.main__items-box--tax
               (税込)
 

--- a/db/migrate/20190107092140_create_items.rb
+++ b/db/migrate/20190107092140_create_items.rb
@@ -1,0 +1,11 @@
+class CreateItems < ActiveRecord::Migration[5.0]
+  def change
+    create_table :items do |t|
+      t.string :name, null: false
+      t.text :text, null: false
+      t.text :image
+      t.string :price
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181213062512) do
+ActiveRecord::Schema.define(version: 20190107045002) do
+
+  create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",                     null: false
+    t.string   "text",                     null: false
+    t.text     "image",      limit: 65535
+    t.string   "price"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190107045002) do
+ActiveRecord::Schema.define(version: 20190107092140) do
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                     null: false
-    t.string   "text",                     null: false
+    t.text     "text",       limit: 65535, null: false
     t.text     "image",      limit: 65535
     t.string   "price"
     t.datetime "created_at",               null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Item.create(name:"ジーパン", text: "中古品ですが、保存状態は良いです！", image: "https://www.gap.co.jp/webcontent/0016/185/365/cn16185365.jpg", price: 6000)
+Item.create(name:"Tシャツ", text: "購入したのですが、使用していないので、新品同様です。", image: "https://www.prismacreative.jp/images/printable/tshirts/dalluc_dm501/DM501.png", price: 1500)
+Item.create(name:"靴下", text: "以前年末セールに買った靴下です", image: "http://img21.shop-pro.jp/PA01352/163/product/105051367.jpg?cmsp_timestamp=20160721192907", price: 500)
+Item.create(name:"シューズ", text: "通信販売で購入したのですが、サイズを間違えて購入してしまいました。", image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTjyrzDMV0mUXH4Fp8XtByEWaHag66Q7xEQP9_QKa42oddH6rmETA", price: 3000)

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ItemsController do
+  describe 'GET #index' do
+    it "assigns the requested item to @items" do
+      items = create_list(:item, 3)
+      get :index
+      expect(assigns(:items)).to match(items)
+    end
+
+    it "renders the :index template" do
+      get :index
+      expect(response).to render_template :index
+    end
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item do
+    
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :item do
-    
+    name "積み木"
+    text "子供が使わなくなったおもちゃです"
+    image "hoge.png"
+    price 1000
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 概要
出品してある商品一覧をitems#indexページに表示させる

# 背景
サービス上で購入を可能にするため

## 画像
### 実装画面
[![Image from Gyazo](https://i.gyazo.com/9b16362dfc88fbfab572655363e1c13e.jpg)](https://gyazo.com/9b16362dfc88fbfab572655363e1c13e)

### テスト認証
[![Image from Gyazo](https://i.gyazo.com/4a2a9df9f673e92a2096547ead54f92f.png)](https://gyazo.com/4a2a9df9f673e92a2096547ead54f92f)

## 手順
- seedファイルに記述
- itemsコントローラーのindexアクションで@itemを取得
- Factrybotを用いたテストコードを記述
    - リクエストに対して、items#indexのviewが返ってくるか？
    - 想定しているインスタンス変数が返ってくるか？ 

### 不安なこと
- 他のテーブルがないため、外部キー制約をかけれず、最低限のカラムのみでテーブルを作成したこと(あとで追加する予定)