### PR TITLE
商品出品ページマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,5 @@
 @import "mypage/identification";
 @import "mypage/index";
 @import "mypage/set-profile";
+
+@import "item/new"

--- a/app/assets/stylesheets/item/_new.scss
+++ b/app/assets/stylesheets/item/_new.scss
@@ -1,0 +1,132 @@
+.sell-up {
+  border-top: 1px solid $thin-gray;
+  &__box {
+    width: 620px;
+    padding: 40px;
+  }
+  &__title {
+    font-size: 16px;
+    font-weight: bold;
+    &+p {
+      margin: 8px 0 0;
+      line-height: 1.5;
+    }
+  }
+}
+
+.sell-drop {
+  display: block;
+  width: 620px;
+  margin: 16px auto 0;
+  &__box {
+    width: 620px;
+    margin-left: 0;
+    float: left;
+
+    position: relative;
+    height: 140px;
+    background: $main-back;
+    border: 1px dashed $gray;
+    font-size: 0;
+    text-align: center;
+    &--text {
+      font-weight: bold;
+      position: absolute;
+      top: 50%;
+      left: 16px;
+      right: 16px;
+      text-align: center;
+      font-size: 14px;
+      line-height: 1.5;
+      transform: translate(0, -50%);
+      pointer-events: none;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+  }
+  
+}
+
+.sell-content {
+  padding: 40px;
+  border-top: 1px solid $thin-gray;
+  .input-default {
+    width: 100%;
+    margin: 8px 0 0;
+  }
+  .form-group:first-child {
+    margin: 0;
+  }
+  .form-group {
+    margin-top: 40px;
+  }
+}
+
+.sell-content {
+  
+ 
+  &__box {
+    float: right;
+    width: 400px;
+    margin: 0;
+  } 
+  &__price {
+    &>li:first-child {
+      padding: 0 0 24px;
+      border: 0;
+    }
+    &>li {
+      padding: 24px 0;
+      border-top: 1px solid $gray;
+    }
+    &--title {
+      width: 50%;
+      line-height: 48px;
+      float: left;
+    }
+    &--input {
+      width: 50%;
+      text-align: right;
+      float: right;
+      div {
+        display: inline-block;
+        width: 80%;
+        margin: 0 0 0 5%;
+      }
+    }
+  }
+}
+
+li.clearfix {
+  .sell-content__price--title {
+    width: 50%;
+    line-height: 18px;
+    float: left;
+  }
+}
+
+.select-wrap {
+  margin: 8px 0 0;
+  position: relative;
+  background: $white;
+}
+
+.l-right {
+  float: right;
+}
+
+.sell-btn-box {
+  .btn-red {
+    margin: 40px 0 0;
+  }
+  .btn-gray {
+    width: 45%;
+    margin: 24px auto 0;
+  }
+}
+
+.btn-gray {
+  background: #aaa;
+  border: 1px solid #aaa;
+  color: $white;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,7 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+
+  def new
+  end
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,0 +1,219 @@
+.single
+  = render partial: "config/single-header"
+  %main.single-main
+    .single-main__contents
+      .sell-contents
+        %h2.single-main__title
+          商品の情報を入力
+        %form.sell-up
+          .sell-up__box
+            %h3.sell-up__title
+              出品画像
+              %span.form-require
+                必須
+            %p
+              最大10枚までアップロードできます。
+            
+            .sell-drop.clearfix
+              .sell-drop__box
+                %input
+                .sell-drop__box--text
+                  ドラッグアンドドロップ
+                  またはクリックしてファイルをアップロード
+              
+          .sell-content
+            .form-group
+              %label
+                商品名
+                %span.form-require
+                  必須
+              %div
+                %input{class: "input-default", placeholder: "商品名（必須 40文字まで)"}
+              
+            .form-group
+              %label
+                商品の説明
+                %span.form-require
+                  必須
+              %textarea{class: "textarea-default", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"}
+
+          .sell-content.clearfix
+            %h3.sell-content__title
+              商品の詳細
+            .sell-content__box
+              .form-group
+                %label
+                  カテゴリー
+                  %span.form-require
+                    必須
+                %div
+                  .select-wrap
+                    %select.select-default
+                      %option 
+                        ーーー
+                      %option{value: 1}
+                        レディース
+                      %option{value: 2}
+                        メンズ
+                      %option{value: 3}
+                        ベビー・キッズ
+                      %option{value: 4}
+                        インテリア・住まい・小物
+                      %option{value: 5}
+                        本・音楽・ゲーム
+                      %option{value: 6}
+                        おもちゃ・ホビー・グッズ
+                      %option{value: 7}
+                        コスメ・香水・美容
+                      %option{value: 8}
+                        家電・スマホ・カメラ
+                      %option{value: 9}
+                        スポーツ・レジャー
+                      %option{value: 10}
+                        ハンドメイド
+                      %option{value: 11}
+                        チケット
+                      %option{value: 12}
+                        自動車・オートバイ
+                      %option{value: 13}
+                        その他
+                    = fa_icon 'angle-down', class: "icon icon-angle-down"
+              
+              .form-group
+                %label
+                  商品の状態
+                  %span.form-require
+                    必須
+                %div
+                  .select-wrap
+                    %select.select-default
+                      %option 
+                        ーーー
+                      %option{value: 1}
+                        新品、未使用
+                      %option{value: 2}
+                        未使用に近い
+                      %option{value: 1}
+                        目立った傷や汚れなし
+                      %option{value: 2}
+                        やや傷や汚れあり
+                      %option{value: 1}
+                        傷や汚れあり
+                      %option{value: 2}
+                        全体的に状態が悪い
+                    = fa_icon 'angle-down', class: "icon icon-angle-down"
+
+          .sell-content.clearfix
+            %h3.sell-content__title
+              配送について
+            .sell-content__box
+              .form-group
+                %label
+                  配送料の負担
+                  %span.form-require
+                    必須
+                %div
+                  .select-wrap
+                    %select.select-default
+                      %option 
+                        ーーー
+                      %option{value: 1}
+                        送料込み(出品者負担)
+                      %option{value: 2}
+                        着払い(購入者負担)
+                    = fa_icon 'angle-down', class: "icon icon-angle-down"
+
+              .form-group
+                %label
+                  発送元の地域
+                  %span.form-require
+                    必須
+                %div
+                  .select-wrap
+                    %select.select-default
+                      %option 
+                        ーーー
+                      %option{value: 1}
+                        北海道県
+                      %option{value: 2}
+                        青森県
+                      %option{value: 3}
+                        岩手県
+                      %option{value: 4}
+                        宮城県
+                      %option{value: 5}
+                        秋田県
+                      %option{value: 6}
+                        山形県
+                      %option{value: 7}
+                        福島県
+                      %option{value: 8}
+                        茨城県
+                    = fa_icon 'angle-down', class: "icon icon-angle-down"
+
+              .form-group
+                %label
+                  発送までの日数
+                  %span.form-require
+                    必須
+                %div
+                  .select-wrap
+                    %select.select-default
+                      %option 
+                        ーーー
+                      %option{value: 1}
+                        1~2日で発送
+                      %option{value: 2}
+                        2~3日で発送
+                      %option{value: 3}
+                        4~7日で発送
+                    = fa_icon 'angle-down', class: "icon icon-angle-down"
+
+              
+          .sell-content.clearfix
+            %h3.sell-content__title
+              販売価格(300〜9,999,999)
+            .sell-content__box
+              %ul.sell-content__price
+                %li.form-group
+                  .clearfix
+                    %label.sell-content__price--title
+                      価格
+                      %span.form-require
+                        必須
+                    
+                    .sell-content__price--input
+                      ¥
+                      %div
+                        %input{class: "input-default", placeholder: "例)300"}
+                      
+                %li.clearfix
+                  .sell-content__price--title
+                    販売手数料 (10%)
+                  .l-right
+                    ー
+                %li.clearfix
+                  %label.sell-content__price--title
+                    販売利益
+                  .l-right
+                    ー
+          
+          .sell-content.sell-btn-box
+            %div
+              %p
+                禁止されている出品、行為を必ずご確認ください。
+              %p
+                またブランド品でシリアルナンバー等がある場合はご記載ください。偽ブランドの販売は犯罪であり処罰される可能性があります。
+              %p
+                また、出品をもちまして加盟店規約に同意したことになります。
+            %button{type: "submit",class: "btn-default btn-red"}
+              出品する
+            = link_to "#", class: "btn-default btn-gray" do
+              戻る
+
+
+  
+  = render partial: "config/single-footer"
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
 
+  resources :items, only: [:new]
+
   resources :users do
     collection do
       get :logout


### PR DESCRIPTION
# 概要
商品出品ページのマークアップ

# 背景
商品の出品を可能にするため

## 画像(items#new)
[![Image from Gyazo](https://i.gyazo.com/dbe912a94dddeea07ef80b2fef2f5dc7.gif)](https://gyazo.com/dbe912a94dddeea07ef80b2fef2f5dc7)

## 手順
- items#newの作成
- items#newのマークアップ
- item/_new.scssにパーシャル化

### 不安なこと
特になし